### PR TITLE
Fix timout timer

### DIFF
--- a/example/proxy_conf.yaml.example
+++ b/example/proxy_conf.yaml.example
@@ -15,7 +15,6 @@ MICRO_SERVICES:
   - "plugins/microservices/static_attributes.yaml"
 USER_ID_HASH_SALT: "61a89d2db0b9e1e27d490d050b478fe71f352fddd3528a44157f43e339c6c62f2362fb413179937d96172bf84233317"
 LOGGING:
-  fail_timeout: 60
   version: 1
   formatters:
     simple:

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -70,7 +70,7 @@ class SATOSABase(object):
             self._link_micro_services(self.response_micro_services, self._auth_resp_finish)
 
         self.module_router = ModuleRouter(frontends, backends,
-                                          self.request_micro_services + self.response_micro_services, config)
+                                          self.request_micro_services + self.response_micro_services)
 
     def _link_micro_services(self, micro_services, finisher):
         if not micro_services:

--- a/src/satosa/routing.py
+++ b/src/satosa/routing.py
@@ -3,12 +3,10 @@ Holds satosa routing logic
 """
 import logging
 import re
-import time
 
 from .context import SATOSABadContextError
 from .exception import SATOSAError
 from .logging_util import satosa_logging
-from threading import Timer
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +34,7 @@ class ModuleRouter(object):
     and handles the internal routing between frontends and backends.
     """
 
-    def __init__(self, frontends, backends, micro_services, config):
+    def __init__(self, frontends, backends, micro_services):
         """
         :type frontends: dict[str, satosa.frontends.base.FrontendModule]
         :type backends: dict[str, satosa.backends.base.BackendModule]
@@ -69,20 +67,6 @@ class ModuleRouter(object):
         logger.debug("Loaded backends with endpoints: %s" % backends)
         logger.debug("Loaded frontends with endpoints: %s" % frontends)
         logger.debug("Loaded micro services with endpoints: %s" % micro_services)
-        self.config = config
-        self.timer = {}
-        self.timeout = self.config['LOGGING'].get('fail_timeout',0)
-        if self.timeout > 0:
-            Timer(1, self._cleanup).start()
-
-    def _cleanup(self):
-        while True:
-            #logger.debug("Timout cleanup thread")
-            for k, v in list(self.timer.items()):
-                if not v.is_alive():
-                    del self.timer[k]
-                    logger.debug("Cleanup timer %s" % k)
-            time.sleep(1)
 
     def backend_routing(self, context):
         """
@@ -97,10 +81,6 @@ class ModuleRouter(object):
         satosa_logging(logger, logging.DEBUG, "Routing to backend: %s " % context.target_backend, context.state)
         backend = self.backends[context.target_backend]["instance"]
         context.state[STATE_KEY] = context.target_frontend
-        if self.timeout > 0:
-            self.timer[context.state['SESSION_ID']] = Timer(self.timeout, lambda: satosa_logging(logger, logging.DEBUG, "Timeout timer", context.state))
-            self.timer[context.state['SESSION_ID']].start()
-            satosa_logging(logger, logging.DEBUG, "Started timer (%s)" % self.timeout, context.state)
         return backend
 
     def frontend_routing(self, context):
@@ -118,10 +98,6 @@ class ModuleRouter(object):
         satosa_logging(logger, logging.DEBUG, "Routing to frontend: %s " % target_frontend, context.state)
         context.target_frontend = target_frontend
         frontend = self.frontends[context.target_frontend]["instance"]
-        timer = self.timer.get(context.state['SESSION_ID'])
-        if timer:
-            timer.cancel()
-            satosa_logging(logger, logging.DEBUG, "Stopped timer", context.state)
         return frontend
 
     def _find_registered_endpoint_for_module(self, module, context):

--- a/src/satosa/routing.py
+++ b/src/satosa/routing.py
@@ -71,7 +71,7 @@ class ModuleRouter(object):
         logger.debug("Loaded micro services with endpoints: %s" % micro_services)
         self.config = config
         self.timer = {}
-        self.timeout = self.config['LOGGING'].get('fail_timeout',60)
+        self.timeout = self.config['LOGGING'].get('fail_timeout',0)
         if self.timeout > 0:
             Timer(1, self._cleanup).start()
 


### PR DESCRIPTION
Disables the use of the timeout timer watchdog for failed login attempts.
fail_timeout should be set to 0 (default) to disable timer