### PR TITLE
linked to svs: feature-error-handling-no-affiliation-attribute

### DIFF
--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -222,7 +222,7 @@ class SATOSABase(object):
                                                                 state=json.dumps(
                                                                     error.state.state_dict,
                                                                     indent=4))
-            satosa_logging(logger, logging.INFO, msg, error.state, exc_info=False)
+            satosa_logging(logger, logging.INFO, msg, error.state)
             return self._handle_satosa_authentication_error(error)
 
     def _load_state(self, context):

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -222,7 +222,7 @@ class SATOSABase(object):
                                                                 state=json.dumps(
                                                                     error.state.state_dict,
                                                                     indent=4))
-            satosa_logging(logger, logging.ERROR, msg, error.state, exc_info=True)
+            satosa_logging(logger, logging.INFO, msg, error.state, exc_info=False)
             return self._handle_satosa_authentication_error(error)
 
     def _load_state(self, context):


### PR DESCRIPTION
The changes are linked to the following SVS PR: https://github.com/inacademia-development/svs/pull/33

In case of SATOSAAuthenticationError, the exception stack trace should not be logged. And as this is not a system error, therefore the exception should not be logged as ERROR but INFO.

